### PR TITLE
Add broker info box and human-readable time format support

### DIFF
--- a/pkg/kafka/client_test.go
+++ b/pkg/kafka/client_test.go
@@ -1,0 +1,51 @@
+package kafka
+
+import (
+	"testing"
+)
+
+func TestParseTimeToMilliseconds(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+		name     string
+	}{
+		// Already milliseconds
+		{"1000", "1000", "pure number stays as-is"},
+		{"86400000", "86400000", "large number stays as-is"},
+		
+		// Go duration formats
+		{"1h", "3600000", "1 hour"},
+		{"24h", "86400000", "24 hours"},
+		{"30m", "1800000", "30 minutes"},
+		{"1h30m", "5400000", "1 hour 30 minutes"},
+		{"10s", "10000", "10 seconds"},
+		{"500ms", "500", "500 milliseconds"},
+		
+		// Day and week formats
+		{"1d", "86400000", "1 day"},
+		{"7d", "604800000", "7 days"},
+		{"1w", "604800000", "1 week"},
+		{"2w", "1209600000", "2 weeks"},
+		{"1.5d", "129600000", "1.5 days"},
+		
+		// With spaces
+		{"1 d", "86400000", "1 day with space"},
+		{"2 weeks", "1209600000", "2 weeks spelled out"},
+		{"3 days", "259200000", "3 days spelled out"},
+		
+		// Invalid formats return as-is
+		{"invalid", "invalid", "invalid format"},
+		{"", "", "empty string"},
+		{"abc123", "abc123", "mixed invalid"},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseTimeToMilliseconds(tt.input)
+			if result != tt.expected {
+				t.Errorf("parseTimeToMilliseconds(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/ui/edit_config.go
+++ b/pkg/ui/edit_config.go
@@ -103,9 +103,16 @@ func NewEditConfigModel(client *kafka.Client, topicName, configKey, currentValue
 
 	case isNumeric:
 		// Numeric fields use text input with validation
+		description := fmt.Sprintf("Current value: %s", currentValue)
+		
+		// Add help text for time-based fields
+		if strings.HasSuffix(configKey, ".ms") {
+			description += "\n💡 Tip: You can use formats like 1h, 1d, 7d, 1w (will convert to milliseconds)"
+		}
+		
 		input = huh.NewInput().
 			Title(fmt.Sprintf("Edit %s", configKey)).
-			Description(fmt.Sprintf("Current value: %s", currentValue)).
+			Description(description).
 			Placeholder(currentValue).
 			Value(&model.newValue).
 			Validate(func(s string) error {

--- a/tests/test_broker_info.sh
+++ b/tests/test_broker_info.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Test script for broker info box feature
+# This tests that the broker info box displays:
+# - Broker count
+# - Offline count  
+# - ISR (In-Sync Replicas)
+# - Out-of-sync replicas
+
+echo "Testing Broker Info Box Feature"
+echo "================================"
+echo ""
+echo "The broker info box should display on the right side of the brokers list with:"
+echo "  ✓ Total brokers count"
+echo "  ✓ Online/Offline status"
+echo "  ✓ Controller node ID"
+echo "  ✓ Total partitions across all topics"
+echo "  ✓ Total replicas"
+echo "  ✓ Under-replicated partitions"
+echo "  ✓ Offline partitions (if any)"
+echo ""
+echo "To test:"
+echo "1. Start kconduit: ./kconduit -b localhost:9092"
+echo "2. Navigate to Brokers tab (use Tab key)"
+echo "3. Verify the info box appears on the right side (30% width)"
+echo "4. Check that all statistics are displayed correctly"
+echo "5. The stats should update when brokers view is refreshed"
+echo ""
+echo "Expected layout:"
+echo "┌─────────────────────────┐  ┌──────────────┐"
+echo "│  Brokers Table (70%)    │  │ Info Box     │"
+echo "│                         │  │ (30%)        │"
+echo "│  ID | Host | Port ...   │  │              │"
+echo "│  1  | ...               │  │ 📊 Status    │"
+echo "│  2  | ...               │  │ Brokers: 3   │"
+echo "│                         │  │ ✅ All Online│"
+echo "│                         │  │              │"
+echo "│                         │  │ 📈 Replicas  │"
+echo "│                         │  │ Partitions:  │"
+echo "│                         │  │ Replicas:    │"
+echo "└─────────────────────────┘  └──────────────┘"


### PR DESCRIPTION
- Add info box to right side of broker list showing:
  - Total brokers and online/offline status
  - Active controller node
  - Partition and replica statistics with ISR data
  - Under-replicated and offline partition warnings

- Add support for human-readable time formats in topic configs:
  - Users can enter values like '1h', '1d', '7d', '1w'
  - Automatically converts to milliseconds for Kafka
  - Shows helpful tip when editing time-based configs
  - Applies to retention.ms, segment.ms, and other time configs

- Add GetClusterStats() method to fetch real-time ISR statistics
- Fix formatting to show labels and values on same line
- Add comprehensive tests for time parsing functionality
- Maintain 0 linting issues throughout